### PR TITLE
MiuiCamera: Bypass tissot_sprout check

### DIFF
--- a/common/system.prop
+++ b/common/system.prop
@@ -1,7 +1,6 @@
 # This file will be read by resetprop
 # Example: Change dpi
 # ro.sf.lcd_density=320
-ro.product.device=tissot_sprout
 persist.camera.HAL3.enabled=1
 persist.camera.eis.enable=1
 camera.hal1.packagelist=com.whatsapp


### PR DESCRIPTION
The previous patch proposed by me wasn't working because  of some weird signature issue.

I tested this one using the stock 8.1 and it worked fine (the previous one wasn't working, indeed).
Still, I encourage you to test it with a custom rom, but it should work.

I explained what I did in the commit message.